### PR TITLE
Validate and log data during transform

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Unit tests
       run: |
         pip install pytest
+        python -m pytest
     - name: Integration tests
       run: |
         cd tests/integration

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# pip install -e generated
+cdatransform.egg-info/
+
+# Intellij
+.idea/

--- a/cdatransform/transform/gdclib.py
+++ b/cdatransform/transform/gdclib.py
@@ -61,7 +61,7 @@ def entity_to_specimen(transform_in_progress, original, log: LogValidation, **kw
     for specimen in transform_in_progress["Specimen"]:
         for field in ["primary_disease_type", "source_material_type", "anatomical_site"]:
             log.distinct(specimen, field)
-        # days to birth is negative days from birth until diagnosis. 7300 days is 200 years.
+        # days to birth is negative days from birth until diagnosis. 73000 days is 200 years.
         log.validate(specimen, "days_to_birth", lambda x: not x or -73000 < x < 0)
 
     return transform_in_progress

--- a/cdatransform/transform/lib.py
+++ b/cdatransform/transform/lib.py
@@ -52,12 +52,13 @@ def parse_transforms(t_list, t_lib):
 
 
 class Transform:
-    def __init__(self, transform_file) -> None:
+    def __init__(self, transform_file, validate) -> None:
         t_list = yaml.load(open(transform_file, "r"), Loader=Loader)
         self._transforms = parse_transforms(t_list, t_lib)
+        self._validate  = validate
 
     def __call__(self, source: dict) -> dict:
         destination = {}
         for vt in self._transforms:
-            destination = vt[0](destination, source, **vt[1])
+            destination = vt[0](destination, source, self._validate, **vt[1])
         return destination

--- a/cdatransform/transform/main.py
+++ b/cdatransform/transform/main.py
@@ -1,14 +1,10 @@
 import argparse
-import json
-import jsonlines
-import sys
-import time
 import gzip
 import logging
-from typing import Union
+import sys
+import time
 
-import yaml
-from yaml import Loader
+import jsonlines
 
 from cdatransform.lib import get_case_ids
 from cdatransform.transform.lib import Transform
@@ -30,7 +26,7 @@ def filter_cases(reader, case_list):
             break
         else:
             if case.get("id") in cases:
-                cases.pop(case.get("id"))
+                cases.remove(case.get("id"))
             yield case
 
 
@@ -79,7 +75,7 @@ def main():
 
     sys.stderr.write(f"Processed {count} cases ({time.time() - t0}).\n")
 
-    validate.generate_report()
+    validate.generate_report(logger)
 
 
 if __name__ == "__main__":

--- a/cdatransform/transform/main.py
+++ b/cdatransform/transform/main.py
@@ -24,9 +24,8 @@ def filter_cases(reader, case_list):
             yield case
         elif len(cases) == 0:
             break
-        else:
-            if case.get("id") in cases:
-                cases.remove(case.get("id"))
+        elif case.get("id") in cases:
+            cases.remove(case.get("id"))
             yield case
 
 

--- a/cdatransform/transform/main.py
+++ b/cdatransform/transform/main.py
@@ -12,7 +12,7 @@ from yaml import Loader
 
 from cdatransform.lib import get_case_ids
 from cdatransform.transform.lib import Transform
-
+from cdatransform.transform.validate import LogValidation
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def filter_cases(reader, case_list):
         else:
             if case.get("id") in cases:
                 cases.pop(case.get("id"))
-                yield case
+            yield case
 
 
 def main():
@@ -59,7 +59,9 @@ def main():
     logger.info("Starting transform run")
     logger.info("----------------------")
 
-    transform = Transform(args.transforms)
+    validate = LogValidation()
+
+    transform = Transform(args.transforms, validate)
 
     t0 = time.time()
     count = 0
@@ -76,3 +78,10 @@ def main():
                     sys.stderr.write(f"Processed {count} cases ({time.time() - t0}).\n")
 
     sys.stderr.write(f"Processed {count} cases ({time.time() - t0}).\n")
+
+    validate.generate_report()
+
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    main()

--- a/cdatransform/transform/validate.py
+++ b/cdatransform/transform/validate.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, Set
+from typing import Dict, Set, Callable, Any, Mapping
 
 
 class LogValidation:
@@ -12,7 +12,7 @@ class LogValidation:
         # map of field name -> invalid value
         self._invalid_fields: Dict[str, str] = {}
 
-    def distinct(self, table, field_name: str) -> str:
+    def distinct(self, table: Mapping[str, Any], field_name: str) -> str:
         """
         For every use of a field in a table, track all distinct values.
         :param table: the table to find the field in
@@ -24,7 +24,7 @@ class LogValidation:
             self._distinct_fields[field_name].add(value)
         return value
 
-    def agree(self, table, record_id: str, fields: list) -> None:
+    def agree(self, table: Mapping[str, Any], record_id: str, fields: list) -> None:
         """
         Given an ID and a list of field names, track all values seen. For the same ID, the field values should match.
         :param table: the table to find the fields in
@@ -44,7 +44,13 @@ class LogValidation:
                 if value:
                     self._matching_fields[record_id][field] = {value}
 
-    def validate(self, table, field_name, f):
+    def validate(self, table: Mapping[str, Any], field_name: str, f: Callable[[Any], bool]) -> None:
+        """
+        Validate a field in table using function f. Invalid values are collected for reporting.
+        :param table: the table that contains the field
+        :param field_name: the field name
+        :param f: called with the field value; if true, the value is valid
+        """
         value = table.get(field_name)
         if not f(value):
             self._invalid_fields[field_name] = value

--- a/cdatransform/transform/validate.py
+++ b/cdatransform/transform/validate.py
@@ -1,0 +1,42 @@
+import logging
+from collections import defaultdict
+
+
+class LogValidation:
+    logger = logging.getLogger(__name__)
+
+    def __init__(self) -> None:
+        self._distinct_fields = defaultdict(set)
+        self._matching_fields = {}
+
+    def distinct(self, table, field_name: str) -> str:
+        """
+        For every use of a field in a table, track all distinct values.
+        :param table: the table to find the field in
+        :param field_name: the field name
+        :return: the value of the field in the table
+        """
+        value = table.get(field_name)
+        self._distinct_fields[field_name].add(value)
+        return value
+
+    def agree(self, table, record_id: str, fields: list) -> None:
+        """
+        Given an ID and a list of field names, track all values seen. For the same ID, the field values should match.
+        :param table: the table to find the fields in
+        :param record_id: the identifier for the record, shared across different rows
+        :param fields: the fields that should match for all records
+        """
+        other = self._matching_fields.get(record_id)
+        if other:
+            for index, field in enumerate(fields):
+                if table.get(field) == other[index]:
+                    self.logger.warning(f"Conflicting Field ID :{record_id}:{field}:{table.get(field)}:{other[index]}")
+        else:
+            self._matching_fields[record_id] = [table.get(field) for field in fields]
+
+    def generate_report(self) -> None:
+        self.logger.info("==== Validation Report ====")
+        for name, values in self._distinct_fields.items():
+            if len(values) != 0:
+                self.logger.info(f"Distinct Field :{name}: {sorted(values, key=lambda x: (x is None, x))}")

--- a/cdatransform/transform/validate.py
+++ b/cdatransform/transform/validate.py
@@ -4,11 +4,11 @@ from typing import Dict, Set
 
 class LogValidation:
 
-    # map of field name -> set of values
-    _distinct_fields: Dict[str, Set] = defaultdict(set)
-
-    # map of ID -> (map of field name -> set of values)
-    _matching_fields: Dict[str, Dict[str, Set[str]]] = {}
+    def __init__(self) -> None:
+        # map of field name -> set of values
+        self._distinct_fields: Dict[str, Set] = defaultdict(set)
+        # map of ID -> (map of field name -> set of values)
+        self._matching_fields: Dict[str, Dict[str, Set[str]]] = {}
 
     def distinct(self, table, field_name: str) -> str:
         """
@@ -50,4 +50,3 @@ class LogValidation:
             for field, values in fields.items():
                 if len(values) > 1:
                     logger.warning(f"Conflicting Field: ID:{id} FIELD:{field} VALUES:{':'.join(sorted(values, key=lambda x: (x is None, x)))}")
-

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,39 @@
+import logging
+from unittest import TestCase
+
+from cdatransform.transform.validate import LogValidation
+
+
+class TestLogValidation(TestCase):
+
+    def test_distinct(self):
+        log = LogValidation()
+        t1 = {"field": "val1", "field2": "val3"}
+        t2 = {"field": "val2"}
+        t3 = {"field2": "val3"}
+        log.distinct(t1, "field")
+        log.distinct(t2, "field")
+        log.distinct(t3, "field")
+        log.distinct(t1, "field2")
+        log.distinct(t2, "field2")
+        log.distinct(t3, "field2")
+
+        with self.assertLogs('test', level='INFO') as cm:
+            log.generate_report(logging.getLogger('test'))
+        self.assertEqual(cm.output, ['INFO:test:==== Validation Report ====',
+                                     "INFO:test:Distinct Field :field: ['val1', 'val2', None]",
+                                     "INFO:test:Distinct Field :field2: ['val3', None]"])
+
+    def test_agree(self):
+        log = LogValidation()
+        t1 = {"field1": "val1", "field2": "val3"}
+        t2 = {"field1": "val2", "field2": "val4"}
+        t3 = {"field1": "val1", "field2": "val5"}
+        log.agree(t1, "id1", ["field1", "field2"])
+        log.agree(t2, "id2", ["field1", "field2"])
+        log.agree(t3, "id1", ["field1", "field2"])
+
+        with self.assertLogs('test', level='INFO') as cm:
+            log.generate_report(logging.getLogger('test'))
+        self.assertEqual(cm.output, ['INFO:test:==== Validation Report ====',
+                                     'WARNING:test:Conflicting Field: ID:id1 FIELD:field2 VALUES:val3:val5'])

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -21,8 +21,8 @@ class TestLogValidation(TestCase):
         with self.assertLogs('test', level='INFO') as cm:
             log.generate_report(logging.getLogger('test'))
         self.assertEqual(cm.output, ['INFO:test:==== Validation Report ====',
-                                     "INFO:test:Distinct Field :field: ['val1', 'val2', None]",
-                                     "INFO:test:Distinct Field :field2: ['val3', None]"])
+                                     'INFO:test:Distinct FIELD:field VALUES:val1:val2',
+                                     'INFO:test:Distinct FIELD:field2 VALUES:val3'])
 
     def test_agree(self):
         log = LogValidation()
@@ -36,4 +36,20 @@ class TestLogValidation(TestCase):
         with self.assertLogs('test', level='INFO') as cm:
             log.generate_report(logging.getLogger('test'))
         self.assertEqual(cm.output, ['INFO:test:==== Validation Report ====',
-                                     'WARNING:test:Conflicting Field: ID:id1 FIELD:field2 VALUES:val3:val5'])
+                                     'WARNING:test:Conflict ID:id1 FIELD:field2 VALUES:val3:val5'])
+
+    def test_validate(self):
+        log = LogValidation()
+        t1 = {"field1": 123}
+        t2 = {"field1": 1234}
+
+        def is_even(x):
+            return x % 2 == 0
+
+        log.validate(t1, "field1", is_even)
+        log.validate(t2, "field1", is_even)
+
+        with self.assertLogs('test', level='INFO') as cm:
+            log.generate_report(logging.getLogger('test'))
+        self.assertEqual(cm.output, ['INFO:test:==== Validation Report ====',
+                                     'WARNING:test:Invalid FIELD:field1 VALUE:123'])


### PR DESCRIPTION
This is one way to validate (and log validations) while transforming input. I used the GDC transform code because the PDC wasn't merged up yet. It would be possible to pull out the validation code to the top level transform, and validate all DC data in one place, as long as there's no DC specific check you'd want to do on the data.

This should address https://github.com/CancerDataAggregator/transform/issues/8