### PR TITLE
Add checksum checking to integration test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,8 @@ jobs:
         python -m pytest
     - name: Integration tests
       run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          brew install md5sha1sum
+        fi
         cd tests/integration
         ./run-test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,4 @@ jobs:
     - name: Integration tests
       run: |
         cd tests/integration
-        extract-gdc gdc.jsonl.gz --cases gdc-case-list.txt  
-        extract-pdc pdc.jsonl.gz --cases pdc-case-list.txt
-        cda-transform gdc.jsonl.gz gdc.transf.jsonl.gz gdc-transform.yml
+        ./run-test.sh

--- a/tests/integration/gdc.transf.jsonl.gz-checksum.txt
+++ b/tests/integration/gdc.transf.jsonl.gz-checksum.txt
@@ -1,0 +1,1 @@
+ecb3fcae1d0caac1141fa8d247c5d120  -

--- a/tests/integration/run-test.sh
+++ b/tests/integration/run-test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+extract-gdc gdc.jsonl.gz --cases gdc-case-list.txt
+extract-pdc pdc.jsonl.gz --cases pdc-case-list.txt
+cda-transform gdc.jsonl.gz gdc.transf.jsonl.gz gdc-transform.yml
+
+# Generate the md5sum for the generated text and compare it with a previous run.
+# Note that md5sum on the gz doesn't work because the gz file has a timestamp in its header.
+gzip --decompress --to-stdout gdc.transf.jsonl.gz | md5sum --status --check gdc.transf.jsonl.gz-checksum.txt
+RESULT=$?
+if [ $RESULT -ne 0 ]; then
+  echo ERROR
+  cat transform.log
+else
+  # Only delete output if no error occurred.
+  rm -f gdc.jsonl.gz pdc.jsonl.gz gdc.transf.jsonl.gz transform.log
+fi
+exit $RESULT


### PR DESCRIPTION
Currently the integration test only runs the tools but doesn't examine the output. This change computes a checksum on the output of the GDC transform and fails if the checksum has changed.

This only works if the output of the tools are stable over time and aren't dependent on python set ordering, time stamps, etc. It seems to work so far.

This also pulls the test run code out of the github workflow source so it can easily be run during development.