### PR TITLE
update `agree_sources` to report all values in the case where any values have a mismatch

### DIFF
--- a/cdatransform/transform/validate.py
+++ b/cdatransform/transform/validate.py
@@ -6,18 +6,12 @@ class NamedValue:
 
     def __init__(self, value: Any,  name: Optional[str] = None) -> None:
         self._name = name
-        self._value = value
-
-    def __hash__(self) -> int:
-        return self._value.__hash__()
-
-    def __eq__(self, other) -> int:
-        return self._value == other._value
+        self.value = value
 
     def __str__(self) -> str:
         if self._name is not None:
-            return f"{self._name}-{self._value}"
-        return str(self._value)
+            return f"{self._name}-{self.value}"
+        return str(self.value)
 
 
 class LogValidation:
@@ -129,7 +123,7 @@ class LogValidation:
 
         for id, fields in self._matching_fields.items():
             for field, values in fields.items():
-                if len(values) > 1:
+                if len({nv.value for nv in values}) > 1:
                     values_data = sorted([str(v) for v in values])
                     logger.warning(
                         f"Conflict ID:{id} FIELD:{field} VALUES:{':'.join(values_data)}"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -38,7 +38,7 @@ class TestLogValidation(TestCase):
         log = LogValidation()
         t1 = {"field1": "val1", "field2": "val3"}
         t2 = {"field1": "val1", "field2": "val4"}
-        t3 = {"field1": "val1", "field2": "val5"}
+        t3 = {"field1": "val1", "field2": "val3"}
         log.agree_sources({"t1": t1, "t2": t2, "t3": t3}, "id1", ["field1", "field2"])
 
         with self.assertLogs('test', level='INFO') as cm:
@@ -46,7 +46,7 @@ class TestLogValidation(TestCase):
         self.assertEqual(
             cm.output,
             ['INFO:test:==== Validation Report ====',
-             'WARNING:test:Conflict ID:id1 FIELD:field2 VALUES:t1-val3:t2-val4:t3-val5'])
+             'WARNING:test:Conflict ID:id1 FIELD:field2 VALUES:t1-val3:t2-val4:t3-val3'])
 
     def test_validate(self):
         log = LogValidation()


### PR DESCRIPTION
Given the code:
```
        t1 = {"field1": "val1", "field2": "val3"}
        t2 = {"field1": "val1", "field2": "val4"}
        t3 = {"field1": "val1", "field2": "val3"}
        log.agree_sources({"t1": t1, "t2": t2, "t3": t3}, "id1", ["field1", "field2"])
```
This output is generated
```
WARNING:test:Conflict ID:id1 FIELD:field2 VALUES:t1-val3:t2-val4:t3-val3
```